### PR TITLE
Refactored ConvertibleConversionStrategy

### DIFF
--- a/BizArk.Core/Convert/Strategies/ConvertibleConversionStrategy.cs
+++ b/BizArk.Core/Convert/Strategies/ConvertibleConversionStrategy.cs
@@ -21,106 +21,18 @@ namespace BizArk.Core.Convert.Strategies
 		public bool TryConvert(object value, Type to, out object convertedValue)
 		{
 			convertedValue = null;
-			IConvertible convertible = value as IConvertible;
-			if (convertible == null) return false;
+			if (!(value is IConvertible)) return false;
 
 			var cto = GetTrueType(to);
 			var provider = CultureInfo.CurrentCulture;
 
 			try
 			{
-				if (cto == typeof(bool))
+				if (cto.Implements(typeof(IConvertible)))
 				{
-					convertedValue = convertible.ToBoolean(provider);
+					convertedValue = System.Convert.ChangeType(value, cto, provider);
 					return true;
 				}
-
-				if (cto == typeof(char))
-				{
-					convertedValue = convertible.ToChar(provider);
-					return true;
-				}
-
-				if (cto == typeof(sbyte))
-				{
-					convertedValue = convertible.ToSByte(provider);
-					return true;
-				}
-
-				if (cto == typeof(byte))
-				{
-					convertedValue = convertible.ToByte(provider);
-					return true;
-				}
-
-				if (cto == typeof(short))
-				{
-					convertedValue = convertible.ToInt16(provider);
-					return true;
-				}
-
-				if (cto == typeof(ushort))
-				{
-					convertedValue = convertible.ToUInt16(provider);
-					return true;
-				}
-
-				if (cto == typeof(int))
-				{
-					convertedValue = convertible.ToInt32(provider);
-					return true;
-				}
-
-				if (cto == typeof(uint))
-				{
-					convertedValue = convertible.ToUInt32(provider);
-					return true;
-				}
-
-				if (cto == typeof(long))
-				{
-					convertedValue = convertible.ToInt64(provider);
-					return true;
-				}
-
-				if (cto == typeof(ulong))
-				{
-					convertedValue = convertible.ToUInt64(provider);
-					return true;
-				}
-
-				if (cto == typeof(float))
-				{
-					convertedValue = convertible.ToSingle(provider);
-					return true;
-				}
-
-				if (cto == typeof(double))
-				{
-					convertedValue = convertible.ToDouble(provider);
-					return true;
-				}
-
-				if (cto == typeof(decimal))
-				{
-					convertedValue = convertible.ToDecimal(provider);
-					return true;
-				}
-
-				if (cto == typeof(DateTime))
-				{
-					convertedValue = convertible.ToDateTime(provider);
-					return true;
-				}
-
-				if (cto == typeof(string))
-				{
-					convertedValue = convertible.ToString(provider);
-					return true;
-				}
-
-				convertedValue = convertible.ToType(cto, provider);
-				return true;
 			}
 			catch (Exception) { } // Just keep trying other strategies.
 


### PR DESCRIPTION
I have reduced the lines of code needed in the ConvertibleConversionStrategy.cs class by using the System.Convert.ChangeType instead of the multiple if statements that were used before. All the types in the if statements implement IConvertible, so this new change takes advantage of that by simply checking whether the `to` Type implements `IConvertible`. I have also run the conversion tests and everything still passes. Please review and merge it in if you want. Thank you. 