### PR TITLE
"Config" attribute on command-line properties to allow default values to be set in app configuration file.

### DIFF
--- a/BizArk.ConsoleApp.Tests/BizArk.ConsoleApp.Tests.csproj
+++ b/BizArk.ConsoleApp.Tests/BizArk.ConsoleApp.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>

--- a/BizArk.ConsoleApp.Tests/ConsoleAppConfigAttributeTest.cs
+++ b/BizArk.ConsoleApp.Tests/ConsoleAppConfigAttributeTest.cs
@@ -1,0 +1,88 @@
+﻿using BizArk.ConsoleApp.Parser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace BizArk.ConsoleApp.Tests
+{
+    [TestClass]
+    public class ConsoleAppConfigAttributeTest
+    {
+        [TestMethod]
+        public void EvaluateNonConfigAttributeTest()
+        {
+            //Arrange
+            var config = new Mock<IConfigurationProvider>();
+            //Act
+            var app = new TestConsoleApp(config.Object);
+            //Assert
+            Assert.IsNull(app.Test);
+            Assert.IsNull(app.SpecificValue);
+            Assert.IsNull(app.NonConfigProperty);
+        }
+        [TestMethod]
+        public void EvaluateConfigAttributeTestStatic()
+        {
+            //Arrange
+            var config = new Mock<IConfigurationProvider>();
+            config.Setup(c => c.GetSetting(It.IsAny<string>())).Returns("static");
+            //Act
+            var app = new TestConsoleApp(config.Object);
+            //Assert
+            Assert.AreEqual("static", app.Test);
+            Assert.AreEqual("static", app.SpecificValue);
+            Assert.IsNull(app.NonConfigProperty);
+        }
+        [TestMethod]
+        public void EvaluateConfigAttributeTestDynamic()
+        {
+            var config = new Mock<IConfigurationProvider>();
+            config.Setup(c => c.GetSetting(It.IsAny<string>())).Returns((string input) => String.Concat(input, "value"));
+           
+            //act
+            var app = new TestConsoleApp(config.Object);
+
+            //assert
+            Assert.AreEqual("Testvalue", app.Test);
+            Assert.AreEqual("SpecificValuevalue", app.SpecificValue);
+            Assert.IsNull(app.NonConfigProperty);
+        }
+        [TestMethod]
+        public void EvaluateConfigAttributeTestMultiple()
+        {
+            var config = new Mock<IConfigurationProvider>();
+            config.Setup(c => c.GetSetting(It.IsAny<string>())).Returns((string input) => String.Concat(input, "value"));
+            config.Setup(c => c.GetSetting(It.Is<String>(s => s == "SpecificValue"))).Returns("SpecificResult");
+            //act
+            var app = new TestConsoleApp(config.Object);
+
+            //assert
+            Assert.AreEqual("Testvalue", app.Test);
+            Assert.AreEqual("SpecificResult", app.SpecificValue);
+            Assert.IsNull(app.NonConfigProperty);
+        }
+    }
+    public class TestConsoleApp : BaseConsoleApp
+    {
+        public TestConsoleApp(IConfigurationProvider config) : base(config)
+        {
+        }
+
+        public override int Start()
+        {
+            throw new NotImplementedException();
+        }
+
+        [Config]
+        public string Test { get; set; }
+
+        [Config]
+        public string SpecificValue { get; set; }
+
+        public string NonConfigProperty { get; set; }
+
+    }
+
+}

--- a/BizArk.ConsoleApp/BizArk.ConsoleApp.csproj
+++ b/BizArk.ConsoleApp/BizArk.ConsoleApp.csproj
@@ -14,9 +14,9 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>BizArk command-line parsing command-line-parsing console utility</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
-    <PackageReleaseNotes>No changes. This is the downside of putting multiple projects in the same repository.</PackageReleaseNotes>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <FileVersion>4.0.1.0</FileVersion>
+    <PackageReleaseNotes>Fixed bug where not specifying the CmdLineOptions object with querystring parameters caused a null ref error.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/BizArk.ConsoleApp/BizArk.ConsoleApp.csproj
+++ b/BizArk.ConsoleApp/BizArk.ConsoleApp.csproj
@@ -30,6 +30,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BizArk.Core\BizArk.Core.csproj" />
   </ItemGroup>
 

--- a/BizArk.ConsoleApp/ConfigAttribute.cs
+++ b/BizArk.ConsoleApp/ConfigAttribute.cs
@@ -1,13 +1,46 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace BizArk.ConsoleApp
 {
+    /// <summary>
+    /// Empty decoration that is used in the BaseConsoleApp to pull command line parameter defaults from a configuration file.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    public class ConfigAttribute :Attribute
+    public class ConfigAttribute : Attribute
     {
+    }
+
+    /// <summary>
+    /// .Net Framework configuration manager abstraction
+    /// </summary>
+    public class NetFrameworkConfigProvider: IConfigurationProvider
+    {
+        /// <summary>
+        /// Retrieves a setting using the .Net Framework's ConfigurationManager class
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        public string GetSetting(string key)
+        {
+            return ConfigurationManager.AppSettings[key];
+        }
+    }
+
+    /// <summary>
+    /// An abstraction to allow building configurations using .Net Framework or .Net Standard (or in unit tests)
+    /// </summary>
+    public interface IConfigurationProvider
+    {
+        /// <summary>
+        /// Returns the setting provided by the given key.
+        /// </summary>
+        /// <param name="key">setting key to retrieve</param>
+        /// <returns></returns>
+        string GetSetting(string key);
     }
 }

--- a/BizArk.ConsoleApp/ConfigAttribute.cs
+++ b/BizArk.ConsoleApp/ConfigAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BizArk.ConsoleApp
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ConfigAttribute :Attribute
+    {
+    }
+}

--- a/BizArk.ConsoleApp/ConsoleApp.cs
+++ b/BizArk.ConsoleApp/ConsoleApp.cs
@@ -1,74 +1,126 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Configuration;
 
 namespace BizArk.ConsoleApp
 {
 
-	/// <summary>
-	/// Interface used by BaCon to manage a conole app.
-	/// </summary>
-	public interface IConsoleApp
-	{
+    /// <summary>
+    /// Interface used by BaCon to manage a conole app.
+    /// </summary>
+    public interface IConsoleApp
+    {
         /// <summary>
         /// The method to call to start running the console application.
         /// </summary>
         /// <returns>Environment.ExitCode</returns>
         int Start();
 
-		/// <summary>
-		/// Gets a value that determines if the process should pause before exiting.
-		/// </summary>
-		bool Wait { get; }
+        /// <summary>
+        /// Gets a value that determines if the process should pause before exiting.
+        /// </summary>
+        bool Wait { get; }
 
-		/// <summary>
-		/// Gets a value that determines if help text should be displayed instead of running the console app.
-		/// </summary>
-		bool Help { get; }
+        /// <summary>
+        /// Gets a value that determines if help text should be displayed instead of running the console app.
+        /// </summary>
+        bool Help { get; }
 
-		/// <summary>
-		/// Called if an exception is raised. Return true to indicate the error is handled. If handled, the BaCon object won't display help or set the ExitCode.
-		/// </summary>
-		/// <param name="ex"></param>
-		/// <returns></returns>
-		bool Error(Exception ex);
-	}
+        /// <summary>
+        /// Called if an exception is raised. Return true to indicate the error is handled. If handled, the BaCon object won't display help or set the ExitCode.
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <returns></returns>
+        bool Error(Exception ex);
+    }
 
-	/// <summary>
-	/// A base class that can be used so developers don't have to implement all the methods.
-	/// </summary>
-	public abstract class BaseConsoleApp : IConsoleApp
-	{
+    /// <summary>
+    /// A base class that can be used so developers don't have to implement all the methods.
+    /// </summary>
+    public abstract class BaseConsoleApp : IConsoleApp, IStringIndexedObject
+    {
+        private PropertyDescriptorCollection LogProps;
 
-		/// <summary>
-		/// The method to call to start running the console application.
-		/// </summary>
-		/// <returns>Environment.ExitCode</returns>
-		public abstract int Start();
+        /// <summary>
+        /// The method to call to start running the console application.
+        /// </summary>
+        /// <returns>Environment.ExitCode</returns>
+        public abstract int Start();
 
-		/// <summary>
-		/// Gets or sets a value that determines if help text should be displayed instead of running the console app.
-		/// </summary>
-		[CmdLineArg("?", ShowInUsage = false)]
-		[Description("If true, displays the help text.")]
-		public bool Help { get; set; }
+        /// <summary>
+        /// Gets or sets a value that determines if help text should be displayed instead of running the console app.
+        /// </summary>
+        [CmdLineArg("?", ShowInUsage = false)]
+        [Description("If true, displays the help text.")]
+        public bool Help { get; set; }
 
-		/// <summary>
-		/// Gets or sets a value that determines if the process should pause before exiting.
-		/// </summary>
-		[CmdLineArg(ShowInUsage = false)]
-		[Description("If true, waits for a key to be pressed before exiting the application.")]
-		public bool Wait { get; set; }
+        /// <summary>
+        /// Gets or sets a value that determines if the process should pause before exiting.
+        /// </summary>
+        [CmdLineArg(ShowInUsage = false)]
+        [Description("If true, waits for a key to be pressed before exiting the application.")]
+        public bool Wait { get; set; }
 
-		/// <summary>
-		/// Called if an exception is raised. Return true to indicate the error is handled. If handled, the BaCon object won't display help or set the ExitCode.
-		/// </summary>
-		/// <param name="ex"></param>
-		/// <returns></returns>
-		public virtual bool Error(Exception ex)
-		{
-			return false;
-		}
+        /// <summary>
+        /// Called if an exception is raised. Return true to indicate the error is handled. If handled, the BaCon object won't display help or set the ExitCode.
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <returns></returns>
+        public virtual bool Error(Exception ex)
+        {
+            return false;
+        }
 
-	}
+        public BaseConsoleApp()
+        {
+            LogProps = TypeDescriptor.GetProperties(this.GetType());
+            foreach (var p in this.GetType().GetProperties())
+            {
+                foreach (var a in p.GetCustomAttributes(true))
+                {
+                    if (a is ConfigAttribute)
+                    {
+                        this[p.Name] = ConfigurationManager.AppSettings[p.Name];
+                        break;
+                    }
+                }
+            }
+        }
 
+        public string this[string propertyName]
+        {
+            get { return LogProps[propertyName]?.GetValue(this)?.ToString() ?? ""; }
+            set { LogProps[propertyName]?.SetValue(this, value); }
+        }
+
+        /// <summary>
+        /// Component of the IStringIndexedObject interface that allows safely accessing the indexes
+        /// </summary>
+        /// <param name="name">Index to search for</param>
+        /// <returns></returns>
+        public bool ContainsKey(string name)
+        {
+            return LogProps.Find(name, false) != null;
+        }
+    }
+
+    /// <summary>
+    /// Indicates that the object implements this[] indexing using strings
+    /// </summary>
+    public interface IStringIndexedObject
+    {
+        /// <summary>
+        /// Implement the C# indexing syntax
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        string this[string name] { get; set; }
+
+        /// <summary>
+        /// Allows safe access to indexed values
+        /// </summary>
+        /// <param name="name">The index to search for</param>
+        /// <returns></returns>
+        bool ContainsKey(string name);
+    }
 }

--- a/BizArk.ConsoleApp/ConsoleApp.cs
+++ b/BizArk.ConsoleApp/ConsoleApp.cs
@@ -71,7 +71,17 @@ namespace BizArk.ConsoleApp
             return false;
         }
 
-        public BaseConsoleApp()
+        /// <summary>
+        /// Default constructor will pull configurations from the traditional .NET Framework configuration provider.
+        /// </summary>
+        public BaseConsoleApp() : this(new NetFrameworkConfigProvider()) { }
+
+        /// <summary>
+        /// If an alternate provider is required (Net Core's ConfigurationBuilder, for example, or for unit testing) 
+        /// this constructor can be used. 
+        /// </summary>
+        /// <param name="config">Configuration Provider to be used (</param>
+        public BaseConsoleApp(IConfigurationProvider config)
         {
             LogProps = TypeDescriptor.GetProperties(this.GetType());
             foreach (var p in this.GetType().GetProperties())
@@ -80,13 +90,18 @@ namespace BizArk.ConsoleApp
                 {
                     if (a is ConfigAttribute)
                     {
-                        this[p.Name] = ConfigurationManager.AppSettings[p.Name];
+                        this[p.Name] = config.GetSetting(p.Name);
                         break;
                     }
                 }
             }
         }
 
+        /// <summary>
+        /// BaseConsoleApp implements IStringIndexedObject, meaning it provides this[string i]
+        /// </summary>
+        /// <param name="propertyName"></param>
+        /// <returns>Property value as a string or the Empty String if the value is not set</returns>
         public string this[string propertyName]
         {
             get { return LogProps[propertyName]?.GetValue(this)?.ToString() ?? ""; }


### PR DESCRIPTION
This is some functionality I added to BizArk to allow you to mark command-line attributes as manageable via the system's configuration functionality. I use ConfigurationManager, but there's an interface, IConfigurationProvider (different from Microsoft.Extensions.Configuration.IConfigurationProvider) that allows unit testing and other configuration systems (like the .Net Core approach). Started to implement the MS interface, but the TryGet/out paradigm is a pain to mock.
Sorry for all the extra edit lines in the ConsoleApp class, I didn't notice it reformatting the lines until I was making this pull request.
Also, this makes the application class itself a string-indexed object (i.e `this[string key]`), so you can reference the parameters by key. I needed this originally when I wanted to pass a configuration object to the logic class, but it just made doing the configuration so easy.